### PR TITLE
Ignore macOS AppleDouble files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+._*
 
 pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary
- Adds `._*` to `.gitignore` so macOS AppleDouble resource-fork sidecar files (e.g. `._index.astro`) can't be accidentally committed.
- These files were never tracked in git history, so there's no history rewrite here — just the ignore rule.

## Test plan
- [x] `npm run build` succeeds
- [x] `git fsck` runs clean (previously reported "index file too small" errors on a stray `.git/objects/pack/._pack-*` file, also removed as local housekeeping)