### PR TITLE
Enable reveal animations on mobile

### DIFF
--- a/src/components/blog/GridItem.astro
+++ b/src/components/blog/GridItem.astro
@@ -18,7 +18,7 @@ const link = APP_BLOG?.post?.isEnabled ? getPermalink(post.permalink, 'post') : 
 ---
 
 <article
-  class="mb-6 transition intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade"
+  class="mb-6 transition intersect-once intersect-quarter motion-safe:opacity-0 motion-safe:intersect:animate-fade"
 >
   <div class="relative md:h-64 bg-surface rounded shadow-lg mb-6">
     {

--- a/src/components/blog/ListItem.astro
+++ b/src/components/blog/ListItem.astro
@@ -22,7 +22,7 @@ const link = APP_BLOG?.post?.isEnabled ? getPermalink(post.permalink, 'post') : 
 ---
 
 <article
-  class={`max-w-md mx-auto md:max-w-none grid gap-6 md:gap-8 intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade ${image ? 'md:grid-cols-2' : ''}`}
+  class={`max-w-md mx-auto md:max-w-none grid gap-6 md:gap-8 intersect-once intersect-quarter motion-safe:opacity-0 motion-safe:intersect:animate-fade ${image ? 'md:grid-cols-2' : ''}`}
 >
   {
     image &&

--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -20,7 +20,7 @@ const relatedPosts = post.tags ? await getRelatedPosts(post, 4) : [];
     <BlogHighlightedPosts
       classes={{
         container:
-          'pt-0 lg:pt-0 md:pt-0 intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade',
+          'pt-0 lg:pt-0 md:pt-0 intersect-once intersect-quarter motion-safe:opacity-0 motion-safe:intersect:animate-fade',
       }}
       title="Related Posts"
       linkText="View All Posts"

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -20,8 +20,8 @@ const { post } = Astro.props;
   <article>
     <header
       class={post.image
-        ? 'intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade'
-        : 'intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade'}
+        ? 'intersect-once intersect-quarter motion-safe:opacity-0 motion-safe:intersect:animate-fade'
+        : 'intersect-once intersect-quarter motion-safe:opacity-0 motion-safe:intersect:animate-fade'}
     >
       <div class="flex justify-between flex-col sm:flex-row max-w-3xl mx-auto mt-0 mb-2 px-4 sm:px-6 sm:items-center">
         <p>

--- a/src/components/ui/WidgetWrapper.astro
+++ b/src/components/ui/WidgetWrapper.astro
@@ -19,7 +19,7 @@ const WrapperTag = as;
   </div>
   <div
     class={twMerge(
-      'relative mx-auto max-w-7xl px-4 md:px-6 py-12 md:py-16 lg:py-20 text-foreground intersect-once intersect-quarter intersect-no-queue motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade',
+      'relative mx-auto max-w-7xl px-4 md:px-6 py-12 md:py-16 lg:py-20 text-foreground intersect-once intersect-quarter intersect-no-queue motion-safe:opacity-0 motion-safe:intersect:animate-fade',
       containerClass
     )}
   >

--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -19,7 +19,7 @@ const {
 
 // Marker classes the IntersectionObserver in BasicScripts.astro reads via
 // classList; must stay as literal tokens, not collapsed into a CSS utility.
-const reveal = 'intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade';
+const reveal = 'intersect-once intersect-quarter motion-safe:opacity-0 motion-safe:intersect:animate-fade';
 ---
 
 <section class="relative md:-mt-[76px] not-prose flex-1 flex flex-col" {...id ? { id } : {}}>
@@ -64,7 +64,7 @@ const reveal = 'intersect-once intersect-quarter motion-safe:md:opacity-0 motion
         {content && <Fragment set:html={content} />}
       </div>
       <div
-        class="intersect-once intersect-no-queue intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade"
+        class="intersect-once intersect-no-queue intersect-quarter motion-safe:opacity-0 motion-safe:intersect:animate-fade"
       >
         {
           image && (


### PR DESCRIPTION
## Summary

- remove the medium-breakpoint gate from reveal animation utilities
- enable the existing fade-up animation on mobile for heroes, blog content, related posts, and widget wrappers
- continue honoring users’ reduced-motion preferences

## Validation

- `astro check` (0 errors, warnings, or hints)
- ESLint on all changed files
- Prettier check on all changed files
- `npm run build`

Note: the full `npm run check` reaches ESLint but is blocked by pre-existing macOS `._*` metadata files throughout the workspace; all changed source files pass scoped ESLint and Prettier checks.