### PR TITLE
Credit the header image as resized, add a site-wide views disclaimer

### DIFF
--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -97,6 +97,14 @@ const { post } = Astro.props;
     <div
       class={`measure-wide max-w-300 post-wide prose lg:prose-xl prose-invert prose-headings:heading prose-headings:text-foreground prose-a:text-primary prose-img:rounded-md prose-img:shadow-lg mt-8 prose-headings:scroll-mt-header prose-li:my-0`}
     >
+      {/* Site-wide boilerplate, kept in the template rather than in each post so
+          it cannot be forgotten on a new one. Subdued on purpose: it is a
+          standing notice, not part of the argument. Tailwind Typography selects
+          with `:where()`, so these utilities override the prose defaults without
+          needing `!important`. */}
+      <p class="mt-0 mb-8 text-sm italic text-foreground-subtle">
+        Views expressed here are my own and do not necessarily reflect those of my employer.
+      </p>
       <slot />
     </div>
     <div class="measure mt-8">

--- a/src/data/post/the-warehouse-has-no-address.mdx
+++ b/src/data/post/the-warehouse-has-no-address.mdx
@@ -15,8 +15,6 @@ import Role from '~/components/arch/Role.astro';
 
 _image: ["Rubber Duck in Seoul"](https://www.flickr.com/photos/99958070@N02/15348035017) by travel oriented, resized. Featuring Florentijn Hofman's Rubber Duck. Licensed under [CC BY-SA 2.0](https://creativecommons.org/licenses/by-sa/2.0/)._
 
-_Views expressed here are my own and do not necessarily reflect those of my employer._
-
 When was the last time you went to the gym, changed your air filters, or had enough water to drink? Sometimes it feels like it's been two weeks when it's really been two months. I track everything in a central place under my control, surfacing the charts and graphs that are important to me, with nearly zero maintenance, nearly zero risk, and nearly zero cost.
 
 I'm allergic to all kinds of maintenance, and software is no exception. When I get a haircut I schedule the next one before I leave. When my PlayStation controller dies I unplug the other and plug in the dead one. When there's no toilet paper left, I leave the cardboard tube on the lid while I get more from the closet. I've systematized so many small choices over the years that whole classes of problems just aren't something I think about anymore.

--- a/src/data/post/the-warehouse-has-no-address.mdx
+++ b/src/data/post/the-warehouse-has-no-address.mdx
@@ -13,7 +13,9 @@ import ArchDiagram from '~/components/arch/ArchDiagram.astro';
 import RoleTable from '~/components/arch/RoleTable.astro';
 import Role from '~/components/arch/Role.astro';
 
-_image: ["Rubber Duck in Seoul"](https://www.flickr.com/photos/99958070@N02/15348035017) by travel oriented, featuring Florentijn Hofman's Rubber Duck. Licensed under [CC BY-SA 2.0](https://creativecommons.org/licenses/by-sa/2.0/)._
+_image: ["Rubber Duck in Seoul"](https://www.flickr.com/photos/99958070@N02/15348035017) by travel oriented, resized. Featuring Florentijn Hofman's Rubber Duck. Licensed under [CC BY-SA 2.0](https://creativecommons.org/licenses/by-sa/2.0/)._
+
+_Views expressed here are my own and do not necessarily reflect those of my employer._
 
 When was the last time you went to the gym, changed your air filters, or had enough water to drink? Sometimes it feels like it's been two weeks when it's really been two months. I track everything in a central place under my control, surfacing the charts and graphs that are important to me, with nearly zero maintenance, nearly zero risk, and nearly zero cost.
 


### PR DESCRIPTION
**Image credit.** The header photo on `the-warehouse-has-no-address.mdx` was resized from the Flickr original. CC BY-SA 2.0 clause 4(c) asks for the derivative to be identified in the credit, so the line now reads "by travel oriented, resized." No crop was made, so it says only what happened.

**Views disclaimer.** Adds the standard "views are my own" line to `SinglePost.astro` rather than to individual posts, since it is true of every post and pasting it per-post is a line to forget on the next one. It renders at the head of the post body, subdued — a standing notice rather than part of the argument.

Verified in the build that all four posts pick it up exactly once.

Note on styling: Tailwind Typography selects with `:where()`, so the utility classes on that paragraph override the prose defaults without `!important`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)